### PR TITLE
Fix Building Properties

### DIFF
--- a/1.4/Defs/ThingDefs_Buildings/Buildings.xml
+++ b/1.4/Defs/ThingDefs_Buildings/Buildings.xml
@@ -45,10 +45,6 @@
 		</thingCategories>
 		<building>
 			<spawnedConceptLearnOpportunity>BillsTab</spawnedConceptLearnOpportunity>
-			<sowTag>SupportPlantsOnly</sowTag>
-			<canPlaceOverImpassablePlant>false</canPlaceOverImpassablePlant>
-			<ai_chillDestination>false</ai_chillDestination>
-			<artificialForMeditationPurposes>false</artificialForMeditationPurposes>
 			<buildingTags>
 				<li>Production</li>
 			</buildingTags>
@@ -87,11 +83,4 @@
 		</placeWorkers>
 		<minifiedDef>MinifiedThing</minifiedDef>
 	</ThingDef>
-
-	
-
-
-
-
-
 </Defs>


### PR DESCRIPTION
Fixes some minor errors with building properties that caused the espresso machine to be treated like a floor spot instead of a regular building for things like natural meditation and pruning penalties, plant growth, and idle pawn AI.